### PR TITLE
Add meeting notes Sep-Nov 2023

### DIFF
--- a/docs/2020-2023.md
+++ b/docs/2020-2023.md
@@ -1,5 +1,869 @@
 # Jenkins Governance Meeting Agenda
 
+## 27 Nov 2023
+
+### Attendees 👥
+
+<!-- Handles are GitHub handles -->
+* @MarkEWaite (Mark Waite)
+* @basil (Basil Crow)
+* @uhafner (Ullrich Hafner)
+* @poddingue (Bruno Verachten)
+* @NotMyFault (Alexander Brandes)
+
+### Upcoming Calendar 📆
+
+* Next LTS: 2.426.2, December 13, 2023
+    * Kris Stern is the release lead, [backporting pull request](https://github.com/jenkinsci/jenkins/pull/8721) submitted
+    * Release candidate scheduled for Wednesday November 29, 2023
+* Next weekly release: 2.434
+* Two week break in LTS schedule: 2.426.3, January 24, 2024 (6 weeks after 2.426.2 instead of the usual 4 weeks)
+    * Refer to [developer mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/vfoiV7HAn94/m/ZHo9h6PSGQAJ) for details
+    * No break expected in weekly release schedules
+* Next major events:
+    * FOSDEM 2024 - February 2-4, 2024
+        * Jenkins Contributor Summit Friday February 2, 2024
+            * Jean-Marc Meessen collecting agenda topics in [community forum](https://community.jenkins.io/t/jenkins-contributor-summit-on-feb-2-2024-call-for-topics-and-ideas/10689)
+        * FOSDEM conference Saturday and Sunday February 3-4, 2024
+
+### Agenda
+
+#### News
+
+* Jenkins 2.426.1 released Nov 15, 2023
+    * [Ratings](https://www.jenkins.io/changelog-stable/#v2.426.1) look very good
+        * 79 reports of "no major issues"
+        * 1 report of "I experienced notable issues", but without an issue number
+        * 0 reports of "I had to roll back"
+    * Prototype.js removed
+    * Java 11 end of life administrative monitor shown to users running Java 11
+    * No support for Red Hat Enterprise Linux 7 and derivatives
+    * Java 21 supported
+        * One [Java 21 intermittent memory leak](https://issues.jenkins.io/browse/JENKINS-72325) as reported by automated tests
+            * [Script security plugin pull request](https://github.com/jenkinsci/script-security-plugin/pull/543) merged to resolve the memory leak
+            * [Script security plugin release 1294.v99333c047434](https://github.com/jenkinsci/script-security-plugin/releases/tag/1294.v99333c047434)
+    * Jira issues being watched closely
+        * One issue about adjunct removed that needs more investigation
+
+#### Action Items
+* Mark create issue to drop the weekly build of BOM in favor of human launched build (**done**)
+* Basil create issue to drop middle two lines from BOM full-test label (**done**)
+* Damien create issue to switch agent implementation to virtual machines
+* Ulli propose a PR revising the election process to (**done**)
+    * nominate 1 month earlier
+        * Proposed the pull request, waiting for reviews, needs reviews
+        * December 2 is listed as the transition date, a little surprising compared to end of month or start of month dates
+    * only register voters if more than one person is a candidate for at least one position
+* Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
+    * Election group closed on community.jenkins.io
+    * Need to prepare for the transition December 11
+        * Revise the documentation from last year on the groups that need to be changed
+        * Remove Oleg and add Basil to the appropriate groups at the transition
+        * Refer to the checklist from last year
+    * Timeline
+        * Results announcement (December 11)
+        * Blog post is planned for the December 11 date (last governance meeting, confirm all changes are correct and complete)
+* Mark Waite submit jenkins.io pull request to combine subprojects and SIGs into a single concept - “working groups”
+    * More pull requests needed
+* Retire the Chinese Jenkins site (Kevin Martens)
+    * Kevin has started his local Kubernetes development environment to prototype the transition
+    * Mark still needs to start his local Kubernetes development environment to prototype the transition
+    * Once prototyped, then Kevin and Mark meet with Damien Duportal to review next steps
+    * Kevin Martens (Docs Officer) tracking [help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3379) to replace the Chinese pages with redirects to the English pages
+        * Kevin working with the infrastructure team on the Helm charts implementing the Chinese site
+* Mark Waite draft a proposal to the board for license policy and phrasing changes
+    * No further progress
+    * Allow other licenses like the JSON license
+    * Some other approach?
+    * What license should be used for a library plugin?
+        * License of the wrapped library (if wrapped library has no separate code, then seems likely)
+        * MIT license as used by Jenkins plugins (if abstraction layer in the plugin, then MIT for ours?)
+    * Review responses from other projects to license mixture (e.g. PyPI)
+        * Mostly focuses on OSI approved licenses but include a separate category for other licenses
+            * Have categories for freeware, public domain, and more
+            * Reasonable precedent for allowing a wider range of licenses
+            * Needs more discussion, but being more permissive is working for PyPI
+            * Newer licenses may be more controversial
+* Mark Waite update the governance meeting GitHub repository with the latest meeting notes
+    * No progress
+* Mark provide details of the attribution for the downloads page
+* Basil create the attribution entries for the page
+
+#### Community activity
+
+* Jenkins contributor spotlight
+    * [Linux Foundation contributor statistics](https://jenkins.devstats.cd.foundation/d/7/companies-contributing-in-repository-groups?orgId=1) show 500-600 Jenkins contributors
+        * Vast majority of pull requests from the top 30 contributors
+            * Retaining those top contributors is much more valuable than recruiting new contributors
+    * Retain top Jenkins contributors - advocacy and outreach initiative
+        * Identify the top contributors (Jean-Marc Meessen gathering pull request and other data)
+        * Invite top contributors to answer a survey about their Jenkins contributions and experiences
+        * Convert survey responses into posts highlighting those individuals on a new jenkins.io page
+            * Site content maintained in a [GitHub repository](https://github.com/jenkins-infra/contributor-spotlight)
+            * Site content displayed to users at https://contributors.jenkins.io beginning later this week
+            * Site CI and deployment processes similar to the [stories.jenkins.io site](https://stories.jenkins.io)
+            * Alex Brandes highlight available
+            * Alex Earl pull request is available
+            * Spotlight a new contributor every two weeks
+        * CloudBees has donated funds for a "thank-you" gift for those top 30 contirbutors
+            * Alyssa Tong coordinating the creation and delivery of the "thank you" gift
+    * Request to board members that are active Jenkins developers
+        * Please respond to the survey that you received
+            * If you need the survey link to be sent again
+    * This is not the exclusion of new contributors, but focused on balancing our retention efforts
+    * Good to see the people behind the project, and their experiences
+
+* Java 11, 17, and 21 in Jenkins - Mark Waite
+    * [2+2+2 Java support plan - Jenkins enhancement proposal](https://github.com/MarkEWaite/jep/tree/java-adoption-plan/jep/0000#java-11) submitted
+        * Include the steps of the Java migration as part of the JEP (work estimate, tasks, etc.)
+            * Mark has much more work to do here
+                * Adding a Java version (use Java 21 addition as the pattern)
+                * Making a Java version the recommended version (use Java 17 as the pattern)
+                * Dropping support for a Java version (refer to Java 11 for ideas)
+            * Further refinements to be done in the JEP
+    * Key dates
+        * Oct 2, 2024 - Last Jenkins LTS release to support Java 11
+        * Oct 30, 2024 - First Jenkins LTS to require Java 17
+        * Oct 31, 2024 - end of Java 11 support by Jenkins project
+
+#### Governance Topics
+
+* Letter of recommendation for a Jenkins GSoC contributor
+    * Rishabh Budhouliya request
+        * Applying for an advanced degree program at a University
+        * Requested a letter of recommendation from Mark Waite (GSoC mentor)
+        * Letter of recommendation needs to be from the organization
+            * Mark proposes to provide his letter of recommendation with the Jenkins logo at the top with Mark's role as a GSoC mentor and as a member of the Jenkins board
+        * Ulli needs to write those types of recommendation letters in his University role
+            * When someone has worked with the student (like Mark), Ulli fully supports placing the Jenkins logo on the recommendation and Mark's title as a board member
+        * Add the governance board address as one of the addresses
+
+* [Attribution request](https://github.com/jenkins-infra/jenkins.io/issues/6861) for downloads page from JFrog
+    * Links from the downloads page do not use https://repo.jenkins-ci.org
+    * Good to highlight our sponsors (like JFrog) in multiple ways
+    * Proposed to list sponsors at the end of the downloads page similar to the end of the root page
+        * Include links to a description of the architecture used to distribute Jenkins core and Jenkins plugins
+
+* Board and officer elections - Alexander Brandes
+    * Final announcement from Alex and Ulli for December 11, 2023 changes
+
+* Social media posting status report
+    * Improvements in last two weeks based on guidance
+        * Several social media posts with technical focus
+        * Encourage contributors to propose social media items to share
+            * Proposals to the [advocacy and outreach chat channel](https://app.gitter.im/#/room/#jenkinsci_advocacy-and-outreach-sig:gitter.im)
+        * Proposed to allow "pure social" posts as well, but only as a small fraction of the total posts
+            * May want more "+1" votes on a social topic than on technical topic
+            * Mark discuss further with advocacy and outreach
+
+* Processing the Azure credits donation - Damien Duportal
+    * [Jenkins infrastructure help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3818) is tracking progress
+    * Hope to be using donated credits before end of November, 2023
+
+* Donation of Oracle Cloud costs by CloudBees - Mark Waite
+    * Still no progress from Oracle
+    * Oracle Cloud account remains open until Oracle agrees all invoices are resolved
+    * Total CloudBees donation - $1800 or less
+    * Jenkins project expenses on Oracle Cloud $0.00 since 30 Sep 2023
+    * Agreed to remove this item from the board agenda
+
+## 13 Nov 2023
+
+### Attendees 👥
+
+* @MarkEWaite (Mark Waite)
+* @basil (Basil Crow)
+* @kmartens27 (Kevin Martens)
+* @dduportal (Damien Duportal)
+* @uhafner (Ullrich Hafner)
+* @gounthar (Bruno Verachten)
+* @NotMyFault (Alexander Brandes)
+
+### Upcoming Calendar 📆
+
+* Next LTS: 2.426.1, November 15, 2023
+    * Prototype.js removed
+    * Java 11 end of life administrative monitor shown to users running Java 11
+    * No support for Red Hat Enterprise Linux 7 and derivatives as announced in the [end of life operating system blog post](https://www.jenkins.io/blog/2023/05/30/operating-system-end-of-life/#red-hat-enterprise-linux-7-and-derivatives)
+* Next weekly release: 2.432
+* Next major events:
+    * Jenkins officer and board elections
+        * Nomination of candidates closed Oct 27, 2023
+        * Voter registration closed Nov 5, 2023
+        * Only one candidate for each open position
+            * Board members - Basil Crow, Mark Waite
+            * Officers as currently stand, for another year
+        * Voting from Nov 6 - Dec 1
+        * Results announced Dec 11 - Basil welcome to the board Dec 11, 2023
+
+### Agenda
+
+#### News
+
+* Alex Brandes receives [GitHub Supply Chain Sentinel award](https://github.blog/2023-11-09-celebrating-the-github-awards-2023-recipients/#supply-chain-sentinel-award)
+    * Jenkins [Twitter](https://x.com/jenkinsci/status/1723024441649561635?s=20)
+    * Jenkins [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7128787406882832384)
+
+#### Action Items
+* Mark create issue to drop the weekly build of BOM in favor of human launched build
+* Basil create issue to drop middle two lines from BOM full-test label
+* Damien create issue to switch agent implementation to virtual machines
+* Ulli propose a PR revising the election process to
+    * nominate 1 month earlier
+    * only register voters if more than one person is a candidate for at least one position
+* Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
+    * How to announce the results?
+        * Publish a blog post that there is no vote needed
+        * Follow pattern of last year
+        * Would it be better to first gather candidates, then register voters?
+            * Second year where we did not need to vote
+            * Start a month earlier to search candidates, then do not register voters
+    * 57 registered voters, but no vote needed
+    * Timeline
+        * Nominations are closed (September 18 - October 27)
+            * All roles have at least one nominee
+                * If role is uncontested, then no need to vote
+            * If candidates agree to accept the nomination and they are only nominee, then they are elected
+        * Voter registration is closed (September 18 - November 05)
+        * Voting not needed (November 06 - December 1)
+        * Results announcement (December 11)
+* Mark Waite submit jenkins.io pull request to combine subprojects and SIGs into a single concept - “working groups”
+    * More pull requests needed
+* Retire the Chinese Jenkins site (Kevin Martens)
+    * Kevin, Damien and Mark met to review structure and understand the alternatives
+        * Ready to create a prototype locally, then meet with Damien again
+    * Chinese site link removed from [www.jenkins.io](http://www.jenkins.io) header
+    * Kevin Martens (Docs Officer) tracking [help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3379) to replace the Chinese pages with redirects to the English pages
+        * Kevin working with the infrastructure team on the Helm charts implementing the Chinese site
+* Mark Waite draft a proposal to the board for license policy and phrasing changes
+    * No further progress
+    * Allow other licenses like the JSON license
+    * Some other approach?
+    * What license should be used for a library plugin?
+        * License of the wrapped library (if wrapped library has no separate code, then seems likely)
+        * MIT license as used by Jenkins plugins (if abstraction layer in the plugin, then MIT for ours?)
+    * Review responses from other projects to license mixture (e.g. PyPI)
+        * Mostly focuses on OSI approved licenses but include a separate category for other licenses
+            * Have categories for freeware, public domain, and more
+            * Reasonable precedent for allowing a wider range of licenses
+            * Needs more discussion, but being more permissive is working for PyPI
+            * Newer licenses may be more controversial
+* Mark Waite update the governance meeting GitHub repository with the latest meeting notes
+
+#### Community activity
+
+* Intelligent test report experiment from Kohsuke Kawaguchi
+    * [Developer mailing list request](https://groups.google.com/g/jenkinsci-dev/c/kyqiprKYc68/m/P6ZpxWpLAgAJ) seeking users to explore it
+        * Kohsuke asks, "Would it be OK if I submit the necessary change in the CI pipeline & others to get this feature activated for Jenkins core?"
+        * Mark reply to the message that discussed and agreed
+
+* Java 11, 17, and 21 in Jenkins - Mark Waite
+    * [2+2+2 Java support plan - Jenkins enhancement proposal](https://github.com/MarkEWaite/jep/tree/java-adoption-plan/jep/0000#java-11) submitted
+        * Include the steps of the Java migration as part of the JEP (work estimate, tasks, etc.)
+            * Currently gathered in a block comment in Jenkins core
+            * Making a Java version the recommended version
+            * Dropping support for a Java version
+            * Allow future release leads and other contributors to use the document
+            * Further refinements to be done in the JEP
+    * Summary of discussions
+        * [Jenkins developers mailing list](https://groups.google.com/g/jenkinsci-dev/c/RaAloTTM9CQ/m/kag1KJSVAwAJ) - quiet
+        * [Jenkins users mailing list](https://groups.google.com/g/jenkinsci-users/c/NGDRrNsaDYY/m/zj5RpSNSAQAJ) - quiet
+        * [Jenkins enhancement proposal](https://github.com/MarkEWaite/jep/tree/java-adoption-plan/jep/0000#java-11) - in progress
+    * Key dates
+        * Oct 3, 2023 - Java 11 end of life monitor visible in Jenkins weekly
+        * Nov 15, 2023 - Java 11 end of life monitor visible in Jenkins LTS
+        * Oct 2, 2024 - Last Jenkins LTS release to support Java 11
+        * Oct 30, 2024 - First Jenkins LTS to require Java 17
+        * Oct 31, 2024 - end of Java 11 support by Jenkins project
+* Hacktoberfest complete
+    * Jean-Marc Meessen [message to developer list](https://groups.google.com/g/jenkinsci-dev/c/wwtLLHNYAjo/m/ZcnRpsRUAAAJ)
+
+#### Governance Topics
+
+* Board and officer elections - Alexander Brandes
+    * Final announcement from Alex and Ulli
+* Social media posting guidelines or guidance?
+    * Advocacy and outreach post from Jenkins [Twitter](https://x.com/jenkinsci/status/1723373770499674526?s=20) and [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7129131077603905537) for U.S. Veteran's Day
+        * Good to have more traffic on the Jenkins social media accounts
+        * Awkward to have a U.S. specific holiday that might be misinterpreted by those outside the U.S.
+        * OK to offer a "-1" for a social media post (Bruno)
+        * Ulli wanted information about Jenkins as a dev tool, not celebrating unrelated topics
+            * Holiday comments are unrelated to Jenkins primary
+            * Focus social media on Jenkins topics rather than "social" topics
+            * Things that are a net worth to the developer community
+        * Mark extend guidelines to emphasize developer centric posts rather than social posts
+    * Alex Brandes receives GitHub Supply Chain Sentinel award from Jenkins [Twitter](https://x.com/jenkinsci/status/1723024441649561635?s=20) and [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7128787406882832384)
+        * Positive all around, no concerns
+* Processing the Azure credits donation - Damien Duportal
+    * Create a new MSOP subscription to host ephemeral workloads and retain persistent workloads on existing "MCA" subscription
+    * Use the separate subscription for ephemeral
+    * Focused on new update center, but will start this before end of year
+    * Primary target - ephemeral agent
+* Donation of Oracle Cloud costs by CloudBees - Mark Waite
+    * Still no progress from Oracle
+    * Oracle Cloud account remains open until Oracle agrees all invoices are resolved
+    * Total CloudBees donation - $1800 or less
+    * Jenkins project expenses on Oracle Cloud $0.00 since 30 Sep 2023
+* Jenkins infrastructure costs overview - Damien Duportal
+    * Current infrastructure costs
+    * Cost reduction projects recently completed
+    * Cost reduction projects in progress
+
+## 30 Oct 2023
+
+### Attendees 👥
+
+* @MarkEWaite (Mark Waite)
+* @basil (Basil Crow)
+* @kmartens27 (Kevin Martens)
+* Oleg Nenashev
+
+### Upcoming Calendar 📆
+
+* Next LTS: 2.426.1, November 15, 2023
+    * Prototype.js removed
+    * Java 11 end of life administrative monitor shown to users running Java 11
+    * No support for Red Hat Enterprise Linux 7 and derivatives as announced in the [end of life operating system blog post](https://www.jenkins.io/blog/2023/05/30/operating-system-end-of-life/#red-hat-enterprise-linux-7-and-derivatives)
+* Next weekly release: 2.430
+    * 2 changes proposed for backport to 2.426.1 ([drag and drop handle regression fix](https://github.com/jenkinsci/jenkins/pull/8613) and [Java warning period change](https://github.com/jenkinsci/jenkins/pull/8661))
+    * Remoting backport already included is the desired version
+* Next major events:
+    * Jenkins officer and board elections
+        * Nomination of candidates closed Oct 27, 2023
+        * Voter registration closes Nov 5, 2023
+        * Voting from Nov 6 - Dec 1
+        * Results announced Dec 11
+
+### Agenda
+
+#### News
+
+* Jenkins elections 2023 nominations have closed - Alexander Brandes and Ulli Hafner
+
+#### Action Items
+* Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
+    * 57 registered voters
+    * Timeline
+        * Nominations are closed (September 18 - October 27)
+            * All roles have at least one nominee
+                * If role is uncontested, then no need to vote
+            * If candidates agree to accept the nomination and they are only nominee, then they are elected
+        * Voter registration (September 18 - November 05)
+        * Voting (November 06 - December 1)
+        * Results announcement (December 11)
+* Mark Waite submit jenkins.io pull request to combine subprojects and SIGs into a single concept - “working groups”
+    * More pull requests needed
+* Retire the Chinese Jenkins site (Kevin Martens)
+    * Chinese site link removed from [www.jenkins.io](http://www.jenkins.io) header
+    * Kevin Martens (Docs Officer) tracking [help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3379) to replace the Chinese pages with redirects to the English pages
+        * Need a redirect from https://www.jenkins.io/zh/ to [https://www.jenkins.io/](https://www.jenkins.io/zh/)
+        * Kevin to work with the infrastructure team on the Helm charts implementing the Chinese site
+* Mark Waite draft a proposal to the board for license policy and phrasing changes
+    * Discussed briefly at Linux Foundation Member Summit
+        * Linux Foundation legal team is willing to review proposal
+    * No further progress
+    * Allow other licenses like the JSON license
+    * Some other approach?
+    * What license should be used for a library plugin?
+        * License of the wrapped library (if wrapped library has no separate code, then seems likely)
+        * MIT license as used by Jenkins plugins (if abstraction layer in the plugin, then MIT for ours?)
+    * Review responses from other projects to license mixture (e.g. PyPI)
+        * Mostly focuses on OSI approved licenses but include a separate category for other licenses
+            * Have categories for freeware, public domain, and more
+            * Reasonable precedent for allowing a wider range of licenses
+            * Needs more discussion, but being more permissive is working for PyPI
+            * Newer licenses may be more controversial
+* Mark Waite update the GitHub repository with the latest
+
+#### Community activity
+
+* Java 11, 17, and 21 in Jenkins - Mark Waite
+    * [2+2+2 Java support plan - Jenkins enhancement proposal](https://github.com/MarkEWaite/jep/tree/java-adoption-plan/jep/0000#java-11) submitted
+        * Ready to assign a JEP number and mark as a Draft
+        * Mark Waite to assign the JEP and mark as a Draft
+        * Where should we document the steps of the Java migration
+            * Windows MSI installer
+            * Currently gathered in a block comment in Jenkins core
+            * Making a Java version the recommended version
+            * Dropping support for a Java version (end of life date embedded)
+            * Allow future release leads and other contributors to use the document or other
+            * Mark prefers a checklist for each of the phases of a Java release
+                * Basil will move the checklist from the block comment into a checklist in the release repository
+                * Java 11 end of life late 2024
+                * Java 8 end of life in 2025 or 2026
+                * Java 17 end of life mid 2026
+            * Include in the JEP?
+    * Summary of discussions
+        * [Jenkins developers mailing list](https://groups.google.com/g/jenkinsci-dev/c/RaAloTTM9CQ/m/kag1KJSVAwAJ) - quiet
+        * [Jenkins users mailing list](https://groups.google.com/g/jenkinsci-users/c/NGDRrNsaDYY/m/zj5RpSNSAQAJ) - quiet
+        * [Jenkins enhancement proposal](https://github.com/MarkEWaite/jep/tree/java-adoption-plan/jep/0000#java-11) - in progress
+    * Key dates
+        * Oct 3, 2023 - Java 11 end of life monitor visible in Jenkins weekly
+        * Nov 15, 2023 - Java 11 end of life monitor visible in Jenkins LTS
+        * Oct 2, 2024 - Last Jenkins LTS release to support Java 11
+        * Oct 30, 2024 - First Jenkins LTS to require Java 17
+        * Oct 31, 2024 - end of Java 11 support by Jenkins project
+* Hacktoberfest nearing its end
+    * Jean-Marc Meessen [message to developer list](https://groups.google.com/g/jenkinsci-dev/c/wwtLLHNYAjo/m/ZcnRpsRUAAAJ)
+    * [Friendly Jira issues list](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=19342)
+    * GitHub [good first issues](https://github.com/search?q=org%3Ajenkinsci+good-first-issues&type=issues)
+    * Infrastructure [good first issues](https://github.com/search?q=org%3Ajenkins-infra+good-first-issues&type=issues)
+    * Gitter requests that look for "where to start?"
+
+#### Governance Topics
+
+* Board and officer elections - Alexander Brandes
+    * Final announcement from Alex and Ulli
+* Processing the $40000 Azure credits donation - Mark Waite
+    * Damien Duportal outlined alternatives in email message to the board
+        * Current Jenkins Azure subscription type allows CDF to pay the bills by invoices but does not allow the bills to be paid by credits
+        * Alternatives include:
+            1. Convert subscription type to "MSOP", use credits until exhausted, then switch subscription type back to "MCA" and pay bill by invoices to CDF
+            2. Convert subscription type to "MSOP", use credits until exhausted, then attach a CDF credit card to pay the bill
+            3. Create a new MSOP subscription to host ephemeral workloads and retain persistent workloads on existing "MCA" subscription
+        * Strengths and weaknesses of the alternatives
+            1. Convert subscription type to "MSOP", then switch back to "MCA"
+                * ⚠️ Switch to MSOP and back to MCA may interrupt services, needs help from Tim Jacomb
+                * ⚠️ Switch to MCA took multiple months the last time we did it
+                * ✅ 5 months or more that donated funds pay all Jenkins expenses on Azure
+            2. Convert subscription type to "MSOP" then attach a CDF credit card
+                * ⚠️ Switch to MSOP may interrupt services, needs help from Tim Jacomb
+                * ⚠️ Switch to credit card payment needs help from CDF
+                * ✅ 5 months or more that donated funds pay all Jenkins expenses on Azure
+            3. Create a new MSOP subscription for ephemeral workloads
+                * ⚠️ Requires a new subscription
+                * ⚠️ Requires a valid payment system for the new subscription
+                * ✅ CDF payment process continues uninterrupted
+                * ✅ 10 months or more that donated funds pay part of Jenkins expenses on Azure
+        * Damien prefers option 3 as lower risk of service disruption or complication with CDF payment process
+            * Mark reply to the mail message with the recommendation
+
+* Donation of Oracle Cloud costs by CloudBees - Mark Waite
+    * Oracle Cloud account remains open until Oracle agrees all invoices are resolved
+    * Total CloudBees donation - $1800 or less
+    * Jenkins project expenses on Oracle Cloud $0.00 since 30 Sep 2023
+
+## 16 Oct 2023
+
+### Attendees 👥
+
+<!-- Handles are GitHub handles -->
+* @MarkEWaite (Mark Waite)
+* @uhafner (Ullrich Hafner)
+* @basil (Basil Crow)
+* @poddingue (Bruno Verachten)
+* @kmartens27 (Kevin Martnes)
+
+### Upcoming Calendar 📆
+
+* Next LTS: 2.414.3, October 18, 2023
+* LTS baselne selection Oct 4, 2023
+* Next Security Release TBD
+* Next major events:
+    * Jenkins officer and board elections
+        * Nomination of candidates closes Oct 27, 2023
+        * Voter registration closes Nov 5, 2023
+        * Voting from Nov 6 - Dec 1
+        * Results announced Dec 11
+
+### Agenda
+
+#### News
+
+* Jenkins elections 2023 nominations in progress - Alexander Brandes and Ulli Hafner
+    * Announced by [blog post](https://www.jenkins.io/blog/2023/09/18/board-officer-election-announcement/), [community post](https://community.jenkins.io/t/jenkins-board-and-officer-election-2023/9644), [tweet](https://twitter.com/jenkinsci/status/1703772922593132972), [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7109540080251244546), and [jenkins-infra](https://github.com/jenkins-infra)
+    * Need more nominees
+    * Need more registered voters
+* Cloudflare sponsors Jenkins project
+    * Project to host update center content on Cloudflare R2 buckets worldwide
+        * Reduce AWS costs for the Jenkins project
+* [Java 21 released](https://openjdk.org/projects/jdk/21/) September 19, 2023
+    * Consider a summary blog post with Java 11 end of life, Java 21 support, Java 17 ...
+        * Basil willing to create that blog post when ready
+        * Aligning towards a general plan, good to communicate it later this month
+* [Prototype.js removed from Jenkins 2.426](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/) 3 Oct 2023
+    * 6 months of [work](https://issues.jenkins.io/browse/JENKINS-70906) from Tim Jacomb, Basil Crow, and many others
+    * [Google sheet](https://docs.google.com/spreadsheets/d/1dpaKALZaK0_HIGy6ony3wnegr1frTg3u1lngG4KdoC8/edit#gid=0) shows good status
+    * Exceptions mostly from plugins that integrate to company services and are maintained by the company providing the service
+        * [JFrog Artifactory plugin](https://issues.jenkins.io/browse/JENKINS-71671) not yet released - 23k installs
+        * [CyberRes Fortify plugin](https://issues.jenkins.io/browse/JENKINS-71303) not yet released - 4k installs
+        * [XRay test management plugin](https://github.com/jenkinsci/xray-connector-plugin/issues/75) not yet released - 2k installs
+        * [Synopsys Coverity plugin](https://issues.jenkins.io/browse/JENKINS-71308) not yet released - 1.5k installs
+        * [Tricentis qTest plugin](https://issues.jenkins.io/browse/JENKINS-71309) not yet released - 1.3k installs
+        * [OpenStack Cloud](https://issues.jenkins.io/browse/JENKINS-71310) fixed but unreleased - 900 installs
+* Next LTS baseline selected Wednesday 4 Oct 2023
+    * Jenkins 2.426 expected to be a good choice for 15 Nov 2023 LTS
+* [Google Summer of Code projects](https://www.jenkins.io/projects/gsoc/#gsoc-2023) for 2023
+    * 4 completed successfully
+        * [GitLab plugin modernization](https://www.jenkins.io/projects/gsoc/2023/projects/gitlab-plugin-modernization)
+        * [Docker compose for tutorials](https://www.jenkins.io/projects/gsoc/2023/projects/docker-compose-build)
+        * [Adding probes to plugin health score](https://www.jenkins.io/projects/gsoc/2023/projects/add-probes-to-plugin-health-score)
+        * [Building jenkins.io with alternate tools](https://www.jenkins.io/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool)
+* Prototype.js removed from Jenkins core Oct 3, 2023
+* Java 11 end of life monitor enabled Oct 3, 2023 - end of life Oct 31, 2024
+    * Container images will default to Java 17 in 2.414.3 and in 2.426
+
+#### Action Items
+* Mark add "Budget and Costs" to regular board meeting agenda
+* Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
+    * Timeline
+        * Nomination of candidates (September 18 - October 27)
+        * Voter registration (September 18 - November 05)
+        * Voting (November 06 - December 1)
+        * Results announcement (December 11)
+    * Alexander Brandes documented how to [nominate someone](https://www.jenkins.io/project/election-walkthrough/), and [how CIVS works](https://www.jenkins.io/project/election-walkthrough/#voting); both for voters and the election committee
+    * Waiting for additional nominations for officers and board members
+        * Need more voters to register
+        * Encourage fellow contributors to register
+* Mark Waite [retrospective on signing certificate renewal process](https://docs.google.com/document/d/1BB2TueNTLhK3TcJ5senSSSMdzy9D95DxPXuWNzL3k2s/edit#) and its improvements
+    * Code signing certificate update for MSI and WAR files
+    * PGP signing key update for RPM and DEB files
+        * Debian key packaging improvements (some other projects use that technique now)
+        * Notification and process improvements
+            * Reimbursement improvements
+        * Details being gathered in the [retrospective document](https://docs.google.com/document/d/1BB2TueNTLhK3TcJ5senSSSMdzy9D95DxPXuWNzL3k2s/edit#)
+* Mark Waite submit jenkins.io pull request to combine subprojects and SIGs into a single concept - “working groups”
+    * More pull requests needed
+* Retire the Chinese Jenkins site - deadline for 4 weeks to close (Kevin Martens)
+    * Chinese site link removed from [www.jenkins.io](http://www.jenkins.io) header
+    * Kevin Martens (Docs Officer) tracking [help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3379) to replace the Chinese pages with redirects to the English pages
+        * Need a redirect from https://www.jenkins.io/zh/ to [https://www.jenkins.io/](https://www.jenkins.io/zh/)
+* Mark Waite draft a proposal to the board for license policy and phrasing changes
+    * Allow other licenses like the JSON license
+    * Some other approach?
+    * What license should be used for a library plugin?
+        * License of the wrapped library (if wrapped library has no separate code, then seems likely)
+        * MIT license as used by Jenkins plugins (if abstraction layer in the plugin, then MIT for ours?)
+    * Review responses from other projects to license mixture (e.g. PyPI)
+        * Mostly focuses on OSI approved licenses but include a separate category for other licenses
+            * Have categories for freeware, public domain, and more
+            * Reasonable precedent for allowing a wider range of licenses
+            * Needs more discussion, but being more permissive is working for PyPI
+            * Newer licenses may be more controversial
+
+#### Governance Topics
+
+* Board and officer elections - Alexander Brandes
+    * Process is well documented, running
+* Donation of Oracle Cloud costs by CloudBees - Mark Waite
+    * 2.5 years ago Jenkins infra joined an Oracle Cloud promotional program
+        * Very low cost for first two years (high discount)
+    * Moved archives.jenkins.io to Oracle Cloud (Thanks Olivier Vernin and Mark Waite)
+    * Jan 2023 Oracle Cloud started charging full price
+        * Mark Waite missed the billing notices to his expired personal credit card
+        * Oracle contacted Mark by telephone in August 2023 to be paid the cloud charges
+        * CloudBees agreed to donate the Oracle cloud costs and has assigned a corporate credit card
+        * Oracle invoices currently show $0.00 as amount due
+    * Infra team migrated archives.jenkins.io from Oracle Cloud to DigitalOcean in Sep 2023
+        * As of 30 Sep 2023, no resources allocated on Oracle Cloud, no further costs expected
+        * Sep 2023 charges of $166.82 paid 2 Oct 2023 by CloudBees
+        * No Oracle Cloud costs reported for Oct 1 or Oct 2, none expected in the future
+    * Oracle Cloud account remains open until Oracle agrees all invoices are resolved
+    * Total CloudBees donation - $1800 or less
+
+#### Community activity
+
+* Java 11, 17, and 21 in Jenkins - Mark Waite
+    * Next step - Jenkins enhancement proposal from Mark Waite
+    * [Google doc](https://docs.google.com/document/d/1y3RVlniNmz-5Nd3LI-w58LDf760Ai7FqssP4zHuTv8U/edit?usp=sharing) describes plan that has been discussed with Jenkins board and Jenkins officers
+        * [Diagram](https://docs.google.com/spreadsheets/d/1Gc-0yuYOD5u674qnxbPOWhCU5t9viCJukVj_9b-kwAw/edit#gid=2094671884) that illustrates the transition process to "2+2+2"
+    * Summary of discussions
+        * [Jenkins developers mailing list](https://groups.google.com/g/jenkinsci-dev/c/RaAloTTM9CQ/m/kag1KJSVAwAJ) - quiet
+        * [Jenkins users mailing list](https://groups.google.com/g/jenkinsci-users/c/NGDRrNsaDYY/m/zj5RpSNSAQAJ) - quiet
+        * Jenkins enhancement proposal - Mark Waite to create
+    * Key dates upcoming
+        * Oct 3, 2023 - Java 11 end of life monitor visible in Jenkins weekly
+        * Nov 15, 2023 - Java 11 end of life monitor visible in Jenkins LTS
+        * Aug 7, 2024 - Last Jenkins LTS release to support Java 11
+        * Sep 4, 2024 - First Jenkins LTS to require Java 17
+        * Sep 30, 2024 - end of Java 11 support by Jenkins project
+* Artifactory bandwidth reduction project [https://repo.jenkins-ci.org](https://repo.jenkins-ci.org)
+    * Done, needs final review of log files to confirm final bandwidth reduction
+* Hacktoberfest has started
+    * Jean-Marc Meessen [message to developer list](https://groups.google.com/g/jenkinsci-dev/c/wwtLLHNYAjo/m/ZcnRpsRUAAAJ)
+    * [Friendly Jira issues list](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=19342)
+    * GitHub [good first issues](https://github.com/search?q=org%3Ajenkinsci+good-first-issues&type=issues)
+    * Infrastructure [good first issues](https://github.com/search?q=org%3Ajenkins-infra+good-first-issues&type=issues)
+    * Gitter requests that look for "where to start?"
+    * Ulli noted that many are coming to the GSoC channel in context of Hacktoberfest
+        * Hacktoberfest is GSoC preparation - lots to learn in order to contribute
+
+## 2 Oct 2023
+
+## Attendees 👥
+
+<!-- Handles are GitHub handles -->
+* @MarkEWaite (Mark Waite)
+* @uhafner (Ullrich Hafner)
+* @basil (Basil Crow)
+* @poddingue (Bruno Verachten)
+* @kmartens27 (Kevin Martnes)
+
+## Upcoming Calendar 📆
+
+* Next LTS: 2.414.3, October 18, 2023
+* LTS baselne selection Oct 4, 2023
+* Next Security Release TBD
+* Next major events:
+    * Jenkins officer and board elections
+        * Nomination of candidates closes Oct 27, 2023
+        * Voter registration closes Nov 5, 2023
+        * Voting from Nov 6 - Dec 1
+        * Results announced Dec 11
+
+## Agenda
+
+### News
+
+* Jenkins elections 2023 nominations in progress - Alexander Brandes and Ulli Hafner
+    * Announced by [blog post](https://www.jenkins.io/blog/2023/09/18/board-officer-election-announcement/), [community post](https://community.jenkins.io/t/jenkins-board-and-officer-election-2023/9644), [tweet](https://twitter.com/jenkinsci/status/1703772922593132972), [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7109540080251244546), and [jenkins-infra](https://github.com/jenkins-infra)
+    * Need more nominees
+    * Need more registered voters
+* Cloudflare sponsors Jenkins project
+    * Project to host update center content on Cloudflare R2 buckets worldwide
+        * Reduce AWS costs for the Jenkins project
+* [Java 21 released](https://openjdk.org/projects/jdk/21/) September 19, 2023
+    * Consider a summary blog post with Java 11 end of life, Java 21 support, Java 17 ...
+        * Basil willing to create that blog post when ready
+        * Aligning towards a general plan, good to communicate it later this month
+* [Prototype.js removed from Jenkins 2.426](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/) 3 Oct 2023
+    * 6 months of [work](https://issues.jenkins.io/browse/JENKINS-70906) from Tim Jacomb, Basil Crow, and many others
+    * [Google sheet](https://docs.google.com/spreadsheets/d/1dpaKALZaK0_HIGy6ony3wnegr1frTg3u1lngG4KdoC8/edit#gid=0) shows good status
+    * Exceptions mostly from plugins that integrate to company services and are maintained by the company providing the service
+        * [JFrog Artifactory plugin](https://issues.jenkins.io/browse/JENKINS-71671) not yet released - 23k installs
+        * [CyberRes Fortify plugin](https://issues.jenkins.io/browse/JENKINS-71303) not yet released - 4k installs
+        * [XRay test management plugin](https://github.com/jenkinsci/xray-connector-plugin/issues/75) not yet released - 2k installs
+        * [Synopsys Coverity plugin](https://issues.jenkins.io/browse/JENKINS-71308) not yet released - 1.5k installs
+        * [Tricentis qTest plugin](https://issues.jenkins.io/browse/JENKINS-71309) not yet released - 1.3k installs
+        * [OpenStack Cloud](https://issues.jenkins.io/browse/JENKINS-71310) fixed but unreleased - 900 installs
+* Next LTS baseline selected Wednesday 4 Oct 2023
+    * Jenkins 2.426 expected to be a good choice for 15 Nov 2023 LTS
+* [Google Summer of Code projects](https://www.jenkins.io/projects/gsoc/#gsoc-2023) for 2023
+    * 4 completed successfully
+        * [GitLab plugin modernization](https://www.jenkins.io/projects/gsoc/2023/projects/gitlab-plugin-modernization)
+        * [Docker compose for tutorials](https://www.jenkins.io/projects/gsoc/2023/projects/docker-compose-build)
+        * [Adding probes to plugin health score](https://www.jenkins.io/projects/gsoc/2023/projects/add-probes-to-plugin-health-score)
+        * [Building jenkins.io with alternate tools](https://www.jenkins.io/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool)
+* Prototype.js removed from Jenkins core Oct 3, 2023
+* Java 11 end of life monitor enabled Oct 3, 2023 - end of life Oct 31, 2024
+    * Container images will default to Java 17 in 2.414.3 and in 2.426
+
+### Action Items
+* Mark add "Budget and Costs" to regular board meeting agenda
+* Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
+    * Timeline
+        * Nomination of candidates (September 18 - October 27)
+        * Voter registration (September 18 - November 05)
+        * Voting (November 06 - December 1)
+        * Results announcement (December 11)
+    * Alexander Brandes documented how to [nominate someone](https://www.jenkins.io/project/election-walkthrough/), and [how CIVS works](https://www.jenkins.io/project/election-walkthrough/#voting); both for voters and the election committee
+    * Waiting for additional nominations for officers and board members
+        * Need more voters to register
+        * Encourage fellow contributors to register
+* Mark Waite [retrospective on signing certificate renewal process](https://docs.google.com/document/d/1BB2TueNTLhK3TcJ5senSSSMdzy9D95DxPXuWNzL3k2s/edit#) and its improvements
+    * Code signing certificate update for MSI and WAR files
+    * PGP signing key update for RPM and DEB files
+        * Debian key packaging improvements (some other projects use that technique now)
+        * Notification and process improvements
+            * Reimbursement improvements
+        * Details being gathered in the [retrospective document](https://docs.google.com/document/d/1BB2TueNTLhK3TcJ5senSSSMdzy9D95DxPXuWNzL3k2s/edit#)
+* Mark Waite submit jenkins.io pull request to combine subprojects and SIGs into a single concept - “working groups”
+    * More pull requests needed
+* Retire the Chinese Jenkins site - deadline for 4 weeks to close (Kevin Martens)
+    * Chinese site link removed from [www.jenkins.io](http://www.jenkins.io) header
+    * Kevin Martens (Docs Officer) tracking [help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3379) to replace the Chinese pages with redirects to the English pages
+        * Need a redirect from https://www.jenkins.io/zh/ to [https://www.jenkins.io/](https://www.jenkins.io/zh/)
+* Mark Waite draft a proposal to the board for license policy and phrasing changes
+    * Allow other licenses like the JSON license
+    * Some other approach?
+    * What license should be used for a library plugin?
+        * License of the wrapped library (if wrapped library has no separate code, then seems likely)
+        * MIT license as used by Jenkins plugins (if abstraction layer in the plugin, then MIT for ours?)
+    * Review responses from other projects to license mixture (e.g. PyPI)
+        * Mostly focuses on OSI approved licenses but include a separate category for other licenses
+            * Have categories for freeware, public domain, and more
+            * Reasonable precedent for allowing a wider range of licenses
+            * Needs more discussion, but being more permissive is working for PyPI
+            * Newer licenses may be more controversial
+
+### Governance Topics
+
+* Board and officer elections - Alexander Brandes
+    * Process is well documented, running
+* Donation of Oracle Cloud costs by CloudBees - Mark Waite
+    * 2.5 years ago Jenkins infra joined an Oracle Cloud promotional program
+        * Very low cost for first two years (high discount)
+    * Moved archives.jenkins.io to Oracle Cloud (Thanks Olivier Vernin and Mark Waite)
+    * Jan 2023 Oracle Cloud started charging full price
+        * Mark Waite missed the billing notices to his expired personal credit card
+        * Oracle contacted Mark by telephone in August 2023 to be paid the cloud charges
+        * CloudBees agreed to donate the Oracle cloud costs and has assigned a corporate credit card
+        * Oracle invoices currently show $0.00 as amount due
+    * Infra team migrated archives.jenkins.io from Oracle Cloud to DigitalOcean in Sep 2023
+        * As of 30 Sep 2023, no resources allocated on Oracle Cloud, no further costs expected
+        * Sep 2023 charges of $166.82 paid 2 Oct 2023 by CloudBees
+        * No Oracle Cloud costs reported for Oct 1 or Oct 2, none expected in the future
+    * Oracle Cloud account remains open until Oracle agrees all invoices are resolved
+    * Total CloudBees donation - $1800 or less
+
+### Community activity
+
+* Java 11, 17, and 21 in Jenkins - Mark Waite
+    * Next step - Jenkins enhancement proposal from Mark Waite
+    * [Google doc](https://docs.google.com/document/d/1y3RVlniNmz-5Nd3LI-w58LDf760Ai7FqssP4zHuTv8U/edit?usp=sharing) describes plan that has been discussed with Jenkins board and Jenkins officers
+        * [Diagram](https://docs.google.com/spreadsheets/d/1Gc-0yuYOD5u674qnxbPOWhCU5t9viCJukVj_9b-kwAw/edit#gid=2094671884) that illustrates the transition process to "2+2+2"
+    * Summary of discussions
+        * [Jenkins developers mailing list](https://groups.google.com/g/jenkinsci-dev/c/RaAloTTM9CQ/m/kag1KJSVAwAJ) - quiet
+        * [Jenkins users mailing list](https://groups.google.com/g/jenkinsci-users/c/NGDRrNsaDYY/m/zj5RpSNSAQAJ) - quiet
+        * Jenkins enhancement proposal - Mark Waite to create
+    * Key dates upcoming
+        * Oct 3, 2023 - Java 11 end of life monitor visible in Jenkins weekly
+        * Nov 15, 2023 - Java 11 end of life monitor visible in Jenkins LTS
+        * Aug 7, 2024 - Last Jenkins LTS release to support Java 11
+        * Sep 4, 2024 - First Jenkins LTS to require Java 17
+        * Sep 30, 2024 - end of Java 11 support by Jenkins project
+* Artifactory bandwidth reduction project [https://repo.jenkins-ci.org](https://repo.jenkins-ci.org)
+    * Done, needs final review of log files to confirm final bandwidth reduction
+* Hacktoberfest has started
+    * Jean-Marc Meessen [message to developer list](https://groups.google.com/g/jenkinsci-dev/c/wwtLLHNYAjo/m/ZcnRpsRUAAAJ)
+    * [Friendly Jira issues list](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=19342)
+    * GitHub [good first issues](https://github.com/search?q=org%3Ajenkinsci+good-first-issues&type=issues)
+    * Infrastructure [good first issues](https://github.com/search?q=org%3Ajenkins-infra+good-first-issues&type=issues)
+    * Gitter requests that look for "where to start?"
+    * Ulli noted that many are coming to the GSoC channel in context of Hacktoberfest
+        * Hacktoberfest is GSoC preparation - lots to learn in order to contribute
+
+## 18 Sep 2023
+
+### Attendees 👥
+
+<!-- Handles are GitHub handles -->
+* @MarkEWaite (Mark Waite)
+* @uhafner (Ullrich Hafner)
+* @basil (Basil Crow)
+* @gounthar (Bruno Verachten)
+
+### Upcoming Calendar 📆
+
+* Next LTS: 2.414.2, September 20, 2023
+* Next Security Release 2.414.2 per [jenkinsci-advisories](https://groups.google.com/g/jenkinsci-advisories): September 20, 2023.
+* Next major events:
+    * Jenkins officer and board elections
+        * Nomination of candidates opens today, Sep 18, 2023, closes Oct 27, 2023
+        * Voter registration starts today, closes Nov 5, 2023
+        * Voting from Nov 6 - Dec 1
+        * Results announced Dec 11
+
+### Agenda
+
+#### News
+
+* Jenkins elections 2023 have started
+    * Announced by [blog post](https://www.jenkins.io/blog/2023/09/18/board-officer-election-announcement/), [community post](https://community.jenkins.io/t/jenkins-board-and-officer-election-2023/9644), [tweet](https://twitter.com/jenkinsci/status/1703772922593132972), [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7109540080251244546), and [jenkins-infra](https://github.com/jenkins-infra)
+* Cloudflare sponsors Jenkins project
+    * [Request submitted](https://github.com/jenkins-infra/helpdesk/issues/3636#issuecomment-1662232986) Aug 2, 2023
+    * Request approved Sep 2023
+        * special thanks to @halkeye for his help with a connection at Cloudflare
+* [FIPS-140 Jenkins enhancement proposal - JEP-237](https://github.com/jenkinsci/jep/blob/31859bedd4594df528428ccc737117b44b786fce/jep/237/README.adoc) created by James Nord
+* [Java 21 release](https://openjdk.org/projects/jdk/21/) is scheduled for September 19, 2023
+    * ci.jenkins.io has Java 21 available and ready to use
+    * Jenkins core, plugin BOM, acceptance test harness, and many plugins passing on Java 21
+    * Only test changes required for Java 21 thus far (no production issues detected)
+    * Should we announce this now or include it in a larger announcements
+        * Consider a summary blog post with Java 11 end of life, Java 21 support, Java 17 ...
+            * Basil willing to create that blog post when ready
+* [Google Summer of Code projects](https://www.jenkins.io/projects/gsoc/#gsoc-2023) for 2023
+    * 2 completed successfully
+        * [GitLab plugin modernization](https://www.jenkins.io/projects/gsoc/2023/projects/gitlab-plugin-modernization)
+        * [Docker compose for tutorials](https://www.jenkins.io/projects/gsoc/2023/projects/docker-compose-build)
+    * 2 extended, successful completion expected
+        * [Adding probes to plugin health score](https://www.jenkins.io/projects/gsoc/2023/projects/add-probes-to-plugin-health-score)
+        * [Building jenkins.io with alternate tools](https://www.jenkins.io/projects/gsoc/2023/projects/alternative-jenkinsio-build-tool)
+* Prototype.js scheduled to be removed from Jenkins core Oct 3, 2023
+* Java 11 end of life monitor to be enabled Oct 3, 2023 - end of life Oct 31, 2024
+
+#### Action Items
+* Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
+    * Timeline
+        * Nomination of candidates (September 18 - October 27)
+        * Voter registration (September 18 - November 05)
+        * Voting (November 06 - December 1)
+        * Results announcement (December 11)
+    * Alexander Brandes documented how to [nominate someone](https://www.jenkins.io/project/election-walkthrough/), and [how CIVS works](https://www.jenkins.io/project/election-walkthrough/#voting); both for voters and the election committee
+* Mark Waite submit pull request to replace ICRC link with URC link on top page (**done** and [**merged**](https://github.com/jenkins-infra/jenkins.io/pull/6622))
+* Mark Waite [retrospective on signing certificate renewal process](https://docs.google.com/document/d/1BB2TueNTLhK3TcJ5senSSSMdzy9D95DxPXuWNzL3k2s/edit#) and its improvements
+    * Code signing certificate update for MSI and WAR files
+    * PGP signing key update for RPM and DEB files
+        * Debian key packaging improvements (some other projects use that technique now)
+        * Notification and process improvements
+            * Reimbursement improvements
+        * Details being gathered in the [retrospective document](https://docs.google.com/document/d/1BB2TueNTLhK3TcJ5senSSSMdzy9D95DxPXuWNzL3k2s/edit#)
+* Mark Waite submit jenkins.io pull request to combine subprojects and SIGs into a single concept - “working groups”
+    * More pull requests needed
+* Retire the Chinese Jenkins site - deadline for 4 weeks to close (Kevin Martens)
+    * Chinese site link removed from [www.jenkins.io](http://www.jenkins.io) header
+    * Kevin Martens (Docs Officer) tracking [help desk ticket](https://github.com/jenkins-infra/helpdesk/issues/3379) to replace the Chinese pages with redirects to the English pages
+        * Need a redirect from https://www.jenkins.io/zh/ to [https://www.jenkins.io/](https://www.jenkins.io/zh/)
+* Mark Waite draft a proposal to the board for license policy and phrasing changes
+    * Allow other licenses like the JSON license
+    * Some other approach?
+    * What license should be used for a library plugin?
+        * License of the wrapped library (if wrapped library has no separate code, then seems likely)
+        * MIT license as used by Jenkins plugins (if abstraction layer in the plugin, then MIT for ours?)
+    * Review responses from other projects to license mixture (e.g. PyPI)
+        * Mostly focuses on OSI approved licenses but include a separate category for other licenses
+            * Have categories for freeware, public domain, and more
+            * Reasonable precedent for allowing a wider range of licenses
+            * Needs more discussion, but being more permissive is working for PyPI
+            * Newer licenses may be more controversial
+
+#### Governance Topics
+
+* Board and officer elections - Ulli Hafner
+    * Blog posts created
+    * Process document describes the election process
+    * Announced by [blog post](https://www.jenkins.io/blog/2023/09/18/board-officer-election-announcement/), [community post](https://community.jenkins.io/t/jenkins-board-and-officer-election-2023/9644), [tweet](https://twitter.com/jenkinsci/status/1703772922593132972), [LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7109540080251244546), and [jenkins-infra](https://github.com/jenkins-infra)
+        * Next steps - meet with @NotMyFault
+        * Process is well documented, running
+
+#### Community activity
+
+* Java 11, 17, and 21 in Jenkins - Mark Waite
+    * [Google doc](https://docs.google.com/document/d/1y3RVlniNmz-5Nd3LI-w58LDf760Ai7FqssP4zHuTv8U/edit?usp=sharing) describes plan that has been discussed with Jenkins board and Jenkins officers
+        * Further discussion in this meeting?
+        * [Diagram](https://docs.google.com/spreadsheets/d/1Gc-0yuYOD5u674qnxbPOWhCU5t9viCJukVj_9b-kwAw/edit#gid=2094671884) that illustrates the transition process to "2+2+2"
+    * Summary of discussions
+        * Jenkins developers mailing list - Mark Waite to send
+        * Jenkins users mailing list - Mark Waite to send
+        * Jenkins enhancement proposal - Mark Waite to create JEP
+    * Key dates upcoming
+        * Sep 19, 2023 - Java 21 release
+        * Oct 3, 2023 - Java 11 end of life monitor visible in Jenkins weekly
+        * Oct xx, 2023 - Java 21 supported by Jenkins core and many plugins
+        * Dec 13, 2023 - Java 11 end of life monitor visible in Jenkins LTS
+        * Aug 7, 2024 - Last Jenkins LTS release to support Java 11
+        * Sep 4, 2024 - First Jenkins LTS to require Java 17
+        * Oct 2024 - end of Java 11 support by Jenkins project
+* Artifactory bandwidth reduction project [https://repo.jenkins-ci.org](https://repo.jenkins-ci.org)
+    * JFrog requests implemented and announced in [blog post](https://www.jenkins.io/blog/2023/09/06/artifactory-bandwidth-reduction/)
+        * Open issues being addressed by infrastructure team
+* [Prototype.js removal](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/)
+    * Oct 3, 2023 proposed as the [date to remove Prototype.js from Jenkins core](https://github.com/jenkinsci/jenkins/pull/7781#issuecomment-1679658280)
+    * [Prototype.js removal epic](https://issues.jenkins.io/browse/JENKINS-70906) making good progress
+    * [Tracking sheet](https://docs.google.com/spreadsheets/d/1dpaKALZaK0_HIGy6ony3wnegr1frTg3u1lngG4KdoC8/edit?usp=sharing) shows details
+    * Most popular plugins already updated, with few exceptions
+        * JFrog Artifactory (work starts in September - 23000 installs)
+        * Microfocus Fortify (expected in September or October - 4200 installs)
+        * Xray test management for Jira (no response - 1900 installs)
+        * Synopsys Coverity (no response - 1400 installs)
+        * Tricentis qTest (no response - 1300 installs)
+    * Feature flag available to disable prototype in Jenkins core 2.406 and later
+* Hacktoberfest preparation has started
+    * Jean-Marc Meessen [message to developer list](https://groups.google.com/g/jenkinsci-dev/c/wwtLLHNYAjo/m/ZcnRpsRUAAAJ)
+    * [Friendly Jira issues list](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=19342)
+    * GitHub [good first issues](https://github.com/search?q=org%3Ajenkinsci+good-first-issues&type=issues)
+    * Infrastructure [good first issues](https://github.com/search?q=org%3Ajenkins-infra+good-first-issues&type=issues)
+
 ## Aug 21, 2023
 
 ## Attendees 👥
@@ -25,7 +889,7 @@
 * Alexander Brandes and Ullrich Hafner run the officer and board elections for 2023
     * A timeline has been drafted based on the 2021 timeline:
         * Nomination of candidates (September 18 - October 27)
-        * Voter registration (September 18 - November 05) 
+        * Voter registration (September 18 - November 05)
         * Voting (November 06 - December 1)
         * Results announcement (December 11)
     * Alexander Brandes documented how to [nominate someone](https://www.jenkins.io/project/election-walkthrough/), and [how CIVS works](https://www.jenkins.io/project/election-walkthrough/#voting); both for voters and the election committee
@@ -102,7 +966,6 @@
 * Adoptium asked if we want to be part of their list of Temurin adopters (George Adams)
     * We already state that Temurin is in our container images, agree that we should note in their list
     * Logo comes from artwork, see get.jenkins.io
-
 
 ## Jul 24, 2023
 


### PR DESCRIPTION
Meeting notes copied from community.jenkins.io for archive in this repository.

Once merged, the action item to upload meeting notes is complete until the next meeting.